### PR TITLE
A few minor lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["fastpfor", "compression"]
 categories = ["compression"]
+rust-version = "1.83.0"
 
 [dependencies]
 thiserror = "2.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fastpfor"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.81.0"
 
 [dependencies]
 thiserror = "2.0.7"
@@ -12,7 +12,6 @@ unused_assignments = "allow"
 dead_code = "allow"
 
 [lints.clippy]
-identity_op = "allow"
 unnecessary_cast = "allow"
 ptr_arg = "allow"
 needless_range_loop="allow"

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::identity_op)]
+
 pub fn fast_pack(input: &[i32], inpos: usize, output: &mut [i32], outpos: usize, bit: isize) {
     match bit {
         0 => fast_pack0(input, inpos, output, outpos),
@@ -37,7 +39,7 @@ pub fn fast_pack(input: &[i32], inpos: usize, output: &mut [i32], outpos: usize,
     }
 }
 
-#[allow(unused_variables)]
+#[expect(unused_variables)]
 fn fast_pack0(input: &[i32], inpos: usize, output: &mut [i32], outpos: usize) {
     // Nothing
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
-pub type Result<T> = core::result::Result<T, FastPForError>;
 use thiserror::Error;
+
+pub type FastPForResult<T> = Result<T, FastPForError>;
 
 #[derive(Error, Debug)]
 pub enum FastPForError {

--- a/src/fastpfor.rs
+++ b/src/fastpfor.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use crate::cursor::IncrementCursor;
-use crate::error::Result;
+use crate::error::FastPForResult;
 use crate::{bitpacking, bytebuffer, helpers};
 
 const BLOCK_SIZE_256: i32 = 256;
@@ -47,7 +47,7 @@ impl FastPFOR {
         inlength: i32,
         output: &mut Vec<i32>,
         out_pos: &mut Cursor<i32>,
-    ) -> Result<()> {
+    ) -> FastPForResult<()> {
         let inlength = helpers::greatest_multiple(inlength, self.block_size as i32);
         if self.block_size == BLOCK_SIZE_256 && inlength == 0 {
             // Return early if there is no data to compress
@@ -222,7 +222,7 @@ impl FastPFOR {
         inlength: i32,
         output: &mut Vec<i32>,
         out_pos: &mut Cursor<i32>,
-    ) -> Result<()> {
+    ) -> FastPForResult<()> {
         if inlength == 0 {
             // Return early if there is no data to compress
             return Ok(());

--- a/src/fastpfor.rs
+++ b/src/fastpfor.rs
@@ -316,7 +316,7 @@ impl FastPFOR {
         let run_end = thissize / self.block_size;
         for _ in 0..run_end {
             let b = self.bytes_container.get() as i32;
-            let cexcept = self.bytes_container.get() & 0xFF;
+            let cexcept = self.bytes_container.get();
             for k in (0..self.block_size).step_by(32) {
                 bitpacking::fast_unpack(
                     input,
@@ -332,12 +332,12 @@ impl FastPFOR {
                 let index = maxbits - b;
                 if index == 1 {
                     for _ in 0..cexcept {
-                        let pos = self.bytes_container.get() & 0xFF;
+                        let pos = self.bytes_container.get();
                         output[pos as usize + tmp_out_pos as usize] |= 1 << b;
                     }
                 } else {
                     for _ in 0..cexcept {
-                        let pos = self.bytes_container.get() & 0xFF;
+                        let pos = self.bytes_container.get();
                         let except_value = self.data_to_be_packed[index as usize]
                             [self.data_pointers[index as usize]];
                         output[pos as usize + tmp_out_pos as usize] |= except_value << b;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,27 +6,25 @@ pub fn bits(i: i32) -> usize {
     32 - i.leading_zeros() as usize
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub fn grap_byte(input: &[i32], index: u32) -> u8 {
     (input[(index / 4) as usize] >> (24 - (index % 4) * 8)) as u8
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub fn ceil_by(value: i32, factor: i32) -> i32 {
     value + factor - value % factor
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub fn leading_bit_position(x: u32) -> i32 {
     bitlen(x as u64) as i32
 }
 
-#[allow(dead_code)]
 fn clz(x: u64) -> u64 {
     x.leading_zeros() as u64
 }
 
-#[allow(dead_code)]
 fn bitlen(x: u64) -> i32 {
     if x == 0 {
         return 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,6 @@ mod cursor;
 mod error;
 mod fastpfor;
 mod helpers;
+
+pub use error::{FastPForError, FastPForResult};
+pub use fastpfor::FastPFOR;


### PR DESCRIPTION
@jjcfrancisco it seems there are some valid warnings that should be addressed in the `fastpfor.rs` - please take a look

* bump MSRV to 1.81 to allow `expect` attribute
* switch most lints to `expect`
* remove `identity_op` override, and add it to the bitpacking as expected -- this causes warnings, and should be reviewed.