### PR TITLE
Fix docs build, disable C++ tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastpfor"
-version = "0.6.0"
+version = "0.6.1"
 description = "FastPFOR library written in Rust."
 authors = ["Francisco Jimenez <jjcfrank@gmail.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/jjcfrancisco/fastpfor"

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,10 @@ fn main() {
 
         // Compile FastPFOR using CMake
         println!("cargo:rerun-if-changed=cpp");
-        let lib_path = cmake::Config::new("cpp").build().join("lib");
+        let lib_path = cmake::Config::new("cpp")
+            .define("WITH_TEST", "OFF")
+            .build()
+            .join("lib");
         let lib_path = lib_path.to_str().unwrap();
 
         // Compile the bridge


### PR DESCRIPTION
It seems docs fail to build because C++ code dynamically clones a repo - which is not something docs (and some other systems) allow to do.  Disabling google tests - we don't use them anyway, so compilation should be faster too.